### PR TITLE
Update hookr dependency

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -9,7 +9,7 @@ $hoe = Hoe.new('alter-ego', AlterEgo::VERSION) do |p|
   p.rubyforge_name       = p.name # TODO this is default value
   p.extra_deps         = [
     ['fail-fast',    '~> 1.1.0'],
-    ['hookr',        '~> 1.0.0']
+    ['hookr',        '>= 1.0.0']
   ]
   p.extra_dev_deps = [
     ['newgem', ">= #{::Newgem::VERSION}"]

--- a/lib/alter_ego.rb
+++ b/lib/alter_ego.rb
@@ -1,7 +1,7 @@
 $:.unshift(File.dirname(__FILE__)) unless
   $:.include?(File.dirname(__FILE__)) || $:.include?(File.expand_path(File.dirname(__FILE__)))
 
-gem 'hookr',     "~> 1.0.0"
+gem 'hookr',     ">= 1.0.0"
 gem 'fail-fast', "~> 1.1.0"
 
 require 'forwardable'


### PR DESCRIPTION
Allows versions greater than the 1.0.x series to be used. Newer hookr versions fix issues in ruby 1.9.x.
